### PR TITLE
Add option to allow prioritizing of sources

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -122,6 +122,7 @@ Container.prototype.register = function(comp, sid) {
 Container.prototype.loader =
 Container.prototype.use = function(prefix, fn, options) {
   if (typeof prefix == 'function') {
+    options = fn;
     fn = prefix;
     prefix = '';
   }
@@ -130,10 +131,18 @@ Container.prototype.use = function(prefix, fn, options) {
     throw new Error("Loader requires a function, was passed a '" + (typeof fn) + "'");
     
   }
+  if (typeof options !== 'object') {
+    options = {};
+  }
   if (prefix.length && prefix[prefix.length - 1] != '/') { prefix += '/'; }
   var id = this._order.length;
   this._sources[id] = { prefix: prefix, fn: fn, options: options };
-  this._order.push({ id: id, prefix: prefix, fn: fn });
+  var source = { id: id, prefix: prefix, fn: fn };
+  if (options.priority) {
+    this._order.unshift(source);
+  } else {
+    this._order.push(source);
+  }
 }
 
 Container.prototype.expose = function(cb) {

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -37,4 +37,20 @@ describe('Container', function() {
     
   });
   
+  describe('#loader', function() {
+
+    describe('options', function() {
+      describe('priority', function() {
+        it('should add the source first', function() {
+          var container = new Container();
+          container.loader(function() { return 1; });
+          container.loader(function() { return 2; }, { priority: true });
+
+          var obj = container.create('test');
+          expect(obj).to.equal(2);
+        });
+      });
+    });
+
+  });
 });


### PR DESCRIPTION
When you invoke `container.load()`, it pushes the new source onto the end of an array of sources. What I am trying to do is the opposite -- I want to take my application's existing container, and when setting up the test suites, add a source whose components will shadow the existing ones. Right now, I can do this with `_registerModule()`, but that is obviously private API and not to mention quite clunky.

Is there a reason that you push to sources instead of unshifting? I would normally expect those added later to take precedence, but I'm not sure if there are situations I haven't yet considered. Perhaps there is also a better solution that I haven't considered yet.