### PR TITLE
Resolver windows

### DIFF
--- a/lib/resolvers/id.js
+++ b/lib/resolvers/id.js
@@ -18,7 +18,7 @@
 module.exports = function() {
   
   return function(id) {
-    if (/^[\w\-\.\/]+$/.test(id)) {
+    if (/^[\w\-\.\/\\]+$/.test(id)) {
       return id;
     }
   };

--- a/test/resolvers/id.test.js
+++ b/test/resolvers/id.test.js
@@ -1,4 +1,5 @@
 var factory = require('../../lib/resolvers/id');
+var path = require('path');
 
 describe('resolvers/id', function() {
   
@@ -39,6 +40,10 @@ describe('resolvers/id', function() {
 
     it('should resolve alphabetical identifiers within namespace, also backslash', function() {
       expect(resolve('foo\\bar')).to.equal('foo\\bar');
+    });
+
+    it('should resolve alphabetical identifiers created via `path`', function() {
+      expect(resolve(path.join('foo', 'bar'))).to.equal(path.join('foo', 'bar'));
     });
     
     it('should not resolve identifiers containing spaces', function() {

--- a/test/resolvers/id.test.js
+++ b/test/resolvers/id.test.js
@@ -36,6 +36,10 @@ describe('resolvers/id', function() {
     it('should resolve alphabetical identifiers within namespace', function() {
       expect(resolve('foo/bar')).to.equal('foo/bar');
     });
+
+    it('should resolve alphabetical identifiers within namespace, also backslash', function() {
+      expect(resolve('foo\\bar')).to.equal('foo\\bar');
+    });
     
     it('should not resolve identifiers containing spaces', function() {
       expect(resolve('foo bar')).to.equal(undefined);


### PR DESCRIPTION
I found that built-in resolver did not let paths created with `path` component on Windows to work.
I think this is not what you wanted, as creating paths with `path` is the _right_ way

I hope the test albeit small, is sufficient