### PR TITLE
Literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,20 @@ location where an application's components are found:
 IoC.loader(IoC.node('app/components'));
 ```
 
+#### Injecting a literal component
+
+Manually created components may be directly injected into the container and used as 
+module dependencies.  This is particularly useful in circumstances where a 
+dependency must be created asynchronously.  Manually created components are injected
+using the container's `use()` method and the `literal()` loader:
+
+```javascript
+var myComponent = new MyComponent('a', 'b');
+
+// makes myComponent an injectable dependency with id "myComp"
+IoC.use(IoC.literal('myComp', myComponent));
+```
+
 #### @require vs require()
 
 Loading components is similar in many regards to `require`ing a module, with

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,5 +8,4 @@ exports.Container = Container;
 exports.fs =
 exports.node = require('./loaders/node');
 exports.node_modules = require('./loaders/node_modules');
-
 exports.literal = require('./loaders/literal');

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,3 +8,5 @@ exports.Container = Container;
 exports.fs =
 exports.node = require('./loaders/node');
 exports.node_modules = require('./loaders/node_modules');
+
+exports.literal = require('./loaders/literal');

--- a/lib/loaders/literal.js
+++ b/lib/loaders/literal.js
@@ -1,3 +1,12 @@
+/**
+ * Returns a component definition which will, when queried with the
+ * provided componentId, return the provided literal component.
+ *
+ * @param componentId The identifier for the provided component
+ * @param component The literal component to be added
+ * @returns {Function} To return the provided component when the appropriate
+ * component id is specified.
+ */
 module.exports = function (componentId, component) {
 
     return function (id) {

--- a/lib/loaders/literal.js
+++ b/lib/loaders/literal.js
@@ -1,0 +1,7 @@
+module.exports = function (componentId, component) {
+
+    return function (id) {
+        return (componentId == id) ? component : null;
+    };
+
+};

--- a/test/container.literal.test.js
+++ b/test/container.literal.test.js
@@ -1,57 +1,56 @@
 /* global describe, it, expect */
 
 var Container = require('../lib/container');
-
+var Literal = require('../lib/loaders/literal');
 
 // Bacteria
 
 function Bacteria(food) {
-  this.food = food;
+    this.food = food;
 }
 
-Bacteria.prototype.eat = function() {
-  return this.food;
-}
+Bacteria.prototype.eat = function () {
+    return this.food;
+};
 
+describe.skip('Container#literal', function () {
 
-describe.skip('Container#literal', function() {
-  
-  describe('creating an object', function() {
-    var container = new Container();
-    var lit = new Bacteria('starch');
-    //container.literal('bacteria', lit);
-    
-    //var obj = container.create('bacteria');
-    
-    it('should create an object', function() {
-      expect(obj).to.be.an('object');
-      expect(obj).to.be.an.instanceOf(Bacteria);
-      expect(obj).to.equal(lit);
+    describe('creating an object', function () {
+        var container = new Container();
+        var lit = new Bacteria('starch');
+        container.use(Literal('bacteria', lit));
+
+        var obj = container.create('bacteria');
+
+        it('should create an object', function () {
+            expect(obj).to.be.an('object');
+            expect(obj).to.be.an.instanceOf(Bacteria);
+            expect(obj).to.equal(lit);
+        });
+
+        it('should not create unique instances', function () {
+            var obj2 = container.create('bacteria');
+            expect(obj).to.be.equal(obj2);
+        });
     });
-    
-    it('should not create unique instances', function() {
-      var obj2 = container.create('bacteria');
-      expect(obj).to.be.equal(obj2);
+
+    describe('creating an object from object literal', function () {
+        var container = new Container();
+        var lit = {foo: 'bar'};
+        container.use(Literal('foo', lit));
+
+        var obj = container.create('foo');
+
+        it('should create an object', function () {
+            expect(obj).to.be.an('object');
+            expect(obj).to.be.an.instanceOf(Object);
+            expect(obj).to.equal(lit);
+        });
+
+        it('should not create unique instances', function () {
+            var obj2 = container.create('foo');
+            expect(obj).to.be.equal(obj2);
+        });
     });
-  });
-  
-  describe('creating an object from object literal', function() {
-    var container = new Container();
-    var lit = { foo: 'bar' };
-    //container.literal('foo', lit);
-    
-    //var obj = container.create('foo');
-    
-    it('should create an object', function() {
-      expect(obj).to.be.an('object');
-      expect(obj).to.be.an.instanceOf(Object);
-      expect(obj).to.equal(lit);
-    });
-    
-    it('should not create unique instances', function() {
-      var obj2 = container.create('foo');
-      expect(obj).to.be.equal(obj2);
-    });
-  });
-  
+
 });


### PR DESCRIPTION
Hi there.  I ran into issues converting from 0.0.6 to 0.1.0 when dealing with literal components.  In 0.6.0, I was able to use `IoC.singleton(key, value)` to inject dependencies, but with 0.1.0 this functionality went away.  I noticed you had an existing test that was broken for doing singleton injection, so I thought I'd take a swing at it.

Basically I've followed your "loaders" convention to create a new `IoC.literal(key, value)` loader usable with the `use()` method.  So similar to the `IoC.use(IoC.node(somePath))` syntax, you would use `IoC.use(IoC.literal(id, component))` to inject a literal component.

Not sure if that's the way you had in mind for solving this issue - and if there's a different approach you'd prefer let me know and I'll work that up and submit it instead.  Not a big coding effort - so reworks are cheap ; )