### PR TITLE
Manually register and create

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,20 @@ Electrolyte uses to automatically wire together an application.
 - `@singleton`  Indicates that the component returns a singleton object, which
   should be shared by all components in the application.
 
+#### Register Components Manually
+
+```javascript
+var IoC = require('electrolyte');
+
+var fn = function () {
+  return 'db.instance';
+};
+fn['@singleton'] = true;
+IoC.register('database', fn);
+
+var db = IoC.create('database');
+```
+
 #### Creating Components
 
 Components are created by asking the IoC container to create them:
@@ -108,6 +122,14 @@ Components are created by asking the IoC container to create them:
 var IoC = require('electrolyte');
 
 var db = IoC.create('database');
+```
+
+Or you can pass an array to provide dependencies like below.
+```javascript
+var IoC = require('electrolyte');
+var db = IoC.create('database', [
+  IoC.create('settings')
+]);
 ```
 
 Electrolyte is smart enough to automatically traverse a component's dependencies

--- a/lib/container.js
+++ b/lib/container.js
@@ -65,7 +65,7 @@ util.inherits(Container, EventEmitter);
  * @returns {object}
  * @public
  */
-Container.prototype.create = function(id, parent) {
+Container.prototype.create = function(id, args, parent) {
   if (parent && id[0] == '.') {
     // resolve relative component ID
     id = path.join(path.dirname(parent.id), id);
@@ -96,7 +96,7 @@ Container.prototype.create = function(id, parent) {
     throw new Error("Unable to create object '" + id + "'");
   }
   
-  var obj = spec.create(this);
+  var obj = spec.create(this, args);
   this.emit('create', obj, spec);
   return obj;
 }

--- a/lib/container.js
+++ b/lib/container.js
@@ -180,6 +180,20 @@ Container.prototype._loadSpec = function(id) {
   }
 }
 
+Container.prototype.register = function(id, mod) {
+  var order = this._order
+    , source, prefix;
+  for (var i = 0, len = order.length; i < len; ++i) {
+    source = this._sources[order[i]];
+    prefix = source.prefix;
+    if (id.indexOf(prefix) !== 0) { continue; }
+    if (mod) {
+      this._registerSpec(id, mod, order[i]);
+      break;
+    }
+  }
+}
+
 Container.prototype._registerSpec = function(id, mod, hsource) {
   var dependencies = mod['@require'] || []
     , pattern = 'literal'

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -42,27 +42,27 @@ function Spec(id, dependencies, mod) {
  *
  * @protected
  */
-Spec.prototype.create = function(container) {
+Spec.prototype.create = function(container, args) {
   debug('create %s', this.id);
   
   // Immediately return cached instance.  Optimization for singleton and literal
   // components.
   if (this.instance) { return this.instance; }
-  
+  args = args || [];
   var source = container._sources[this._hsource]
     , deps = this.dependencies
-    , args = []
     , inst, sfn;
-  for (var i = 0, len = deps.length; i < len; ++i) {
-    sfn = container._special[deps[i]];
-    if (sfn) {
-      inst = sfn.call(container, source);
-    } else {
-      inst = container.create(deps[i], this);
-    }
-    args.push(inst);
+  if (!args.length) {
+    for (var i = 0, len = deps.length; i < len; ++i) {
+      sfn = container._special[deps[i]];
+      if (sfn) {
+        inst = sfn.call(container, source);
+      } else {
+        inst = container.create(deps[i], this);
+      }
+      args.push(inst);
+    }  
   }
-    
   var i = this.instantiate.apply(this, args);
   // Cache the instance if the component was annotated as being a singleton.
   if (this.singleton) { this.instance = i; }


### PR DESCRIPTION
Hi,

I've encountered some hassle when I use electrolyte. Here are;

- Electrolyte automatically register components while first attempt to use, if not registered yet. Nice feature. But some case, I need to register components immediately. Not waiting to be registered by another component. Example:
```javascript
var IoC = require('electrolyte');
var arg = function () {
	return 'arg';
};
arg['@singleton'] = true;
IoC.register('arg', arg);

var r = IoC.create('arg');
console.log(r);
```

- Electrolyte automatically create components and resolve whole dependency tree. Some case, I need to provide component dependencies dynamically. It would be nice, if dependencies passed to component with an array.

```javascript
//index.js
var IoC = require('electrolyte');
IoC.use(IoC.node('./components'));

var r1 = IoC.create('test', [
	'emre'
]);
console.log(r1);

var r2 = IoC.create('test', [
	IoC.create('arg1')
]);
console.log(r2);
```

```javascript
//components/test.js
exports = module.exports = function (arg1) {
	return arg1;
};
exports['@require'] = ['arg1'];
exports['@singleton'] = true;
```

```javascript
//components/arg1.js
exports = module.exports = function () {
	return 'arg1';
};
exports['@singleton'] = true;
```