### PR TITLE
fix(spec): don't compute keys for non-objects

### DIFF
--- a/lib/spec.js
+++ b/lib/spec.js
@@ -47,15 +47,15 @@ function Spec(id, mod, source) {
     this.implements = [ this.implements ]
   }
   this.a = {};
-  // FIXME: Doesn't handle functions
-  //if (typeof mod == 'object') {
+  
+  if (typeof mod === 'object' || typeof mod === 'function') {
     keys = Object.keys(mod);
     for (i = 0, len = keys.length; i < len; ++i) {
       if (keys[i].indexOf('@') == 0) {
         this.a[keys[i]] = mod[keys[i]];
       }
     }
-  //}
+  }
   this._source = source;
 }
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
     "node": "*"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js test/**/*.test.js  test/integration/node/*.test.js"
+    "test": "node_modules/.bin/mocha --reporter spec --require test/bootstrap/node test/*.test.js test/**/*.test.js"
   }
 }


### PR DESCRIPTION
I'm not sure what the issue was that led to the `FIXME` comment, so I might just be very naive...
Any reason this didn't work the first time around @jaredhanson ?
Original FIXME commit for reference: https://github.com/jaredhanson/electrolyte/commit/256b3f7bc4d885f04d83f93d1d49a06fb68d8754