### PR TITLE
Added more specific errors, without super-error

### DIFF
--- a/lib/container.js
+++ b/lib/container.js
@@ -88,15 +88,13 @@ Container.prototype.use = function(ns, s, options) {
   this._sources[h] = source;
   this._order.unshift(h);
 
-  Object.keys(manifest)
-    .filter(function (key) { return key != 'load' })
-    .reduce(function (manifest, key) {
-      // hacky use of reduce to keep manifest local variable
-      aid = path.join(source.namespace, key);
-      spec = manifest[key];
-      this._registerSpec(aid, spec, source);
-      return manifest;
-    }.bind(this), manifest);
+  ids = Object.keys(manifest);
+  for (i = 0, len = ids.length; i < len; ++i) {
+    aid = path.join(source.namespace, ids[i]);
+    spec = manifest[ids[i]];
+    if (spec === load) { continue; }
+    this._registerSpec(aid, spec, source);
+  }
 
   return this;
 }

--- a/lib/container.js
+++ b/lib/container.js
@@ -151,7 +151,7 @@ Container.prototype._create = function(id, parent) {
       var self = this;
       this._loadSpec(id, function(err, spec) {
         if (err instanceof SpecNotFoundError) {
-          reject(new CreationFailedError('Unable to create object "' + id + '" required by: ' + (parent && parent.id || 'unknown'))).causedBy(err);
+          reject(new CreationFailedError('Unable to create object "' + id + '" required by: ' + (parent && parent.id || 'unknown')), err);
         } else if (err) {
           return reject(err);
         }

--- a/lib/container.js
+++ b/lib/container.js
@@ -7,7 +7,11 @@ var EventEmitter = require('events')
   , ConstructorSpec = require('./patterns/constructor')
   , LiteralSpec = require('./patterns/literal')
   , InjectedContainer = require('./injectedcontainer')
+  , CreationFailedError = require('./errors/creationfailed')
+  , InvalidArgumentError = require('./errors/invalidargument')
+  , ResolutionFailedError = require('./errors/resolutionfailed')
   , SpecNotFoundError = require('./errors/specnotfound')
+  , SpecInitFailedError = require('./errors/specinitfailed')
   , deprecate = require('depd')('electrolyte')
   , debug = require('debug')('electrolyte');
 
@@ -50,12 +54,13 @@ util.inherits(Container, EventEmitter);
  * a directory on the file system or a package of objects that are specifically
  * designed to function together.
  *
- * @param {string} ns - The namespace under which to mount the source.
- * @param {function} fn - Loader of object specifications from the source.
+ * @param {string?} ns - optional namespace under which to mount the source.
+ * @param {function|object} s - Loader of object specifications from the source.
  * @public
  */
 Container.prototype.use = function(ns, s, options) {
   if (typeof ns !== 'string') {
+    // force ns to be an empty string if not specified
     options = s;
     s = ns;
     ns = '';
@@ -65,29 +70,34 @@ Container.prototype.use = function(ns, s, options) {
   var load = s
     , manifest = {}
     , ids, aid, spec, i, len;
-  
+
+  // accept either object or resolver function
   if (typeof s == 'object') {
     manifest = s;
+    // in case of package do not require the loader as long as we
+    // register all specs
     load = s.load || function noop(id) { return; };
   }
-  
+
   if (typeof load != 'function') {
-    throw new Error("Container#use requires a load function, was passed a '" + (typeof load) + "'");
+    throw new InvalidArgumentError("Container#use requires a `s` to be either object with `load` method or function, '" + (typeof load) + "' has been passed");
   }
   
   var h = this._order.length;
   var source = { namespace: ns, load: load };
   this._sources[h] = source;
   this._order.unshift(h);
-  
-  ids = Object.keys(manifest);
-  for (i = 0, len = ids.length; i < len; ++i) {
-    aid = path.join(source.namespace, ids[i]);
-    spec = manifest[ids[i]];
-    if (spec === load) { continue; }
-    this._registerSpec(aid, spec, source);
-  }
-  
+
+  Object.keys(manifest)
+    .filter(function (key) { return key != 'load' })
+    .reduce(function (manifest, key) {
+      // hacky use of reduce to keep manifest local variable
+      aid = path.join(source.namespace, key);
+      spec = manifest[key];
+      this._registerSpec(aid, spec, source);
+      return manifest;
+    }.bind(this), manifest);
+
   return this;
 }
 Container.prototype.loader = deprecate.function(Container.prototype.use, 'Container#loader: Use Container#use instead');
@@ -142,8 +152,8 @@ Container.prototype._create = function(id, parent) {
     } else {
       var self = this;
       this._loadSpec(id, function(err, spec) {
-        if (err && err.code == 'SPEC_NOT_FOUND') {
-          reject(new Error('Unable to create object "' + id + '" required by: ' + (parent && parent.id || 'unknown')));
+        if (err instanceof SpecNotFoundError) {
+          reject(new CreationFailedError('Unable to create object "' + id + '" required by: ' + (parent && parent.id || 'unknown'))).causedBy(err);
         } else if (err) {
           return reject(err);
         }
@@ -173,7 +183,7 @@ Container.prototype.resolve = function(id, parent) {
     rid = fn(id, parent && parent.id);
     if (rid) { return rid; }
   }
-  throw new Error('Unable to resolve interface "' + id + '" required by: ' + (parent && parent.id || 'unknown'));
+  throw new ResolutionFailedError('Unable to resolve interface "' + id + '" required by: ' + (parent && parent.id || 'unknown'));
 }
 
 

--- a/lib/errors/creationfailed.js
+++ b/lib/errors/creationfailed.js
@@ -1,12 +1,22 @@
-const SuperError = require('super-error');
 /**
- * `CreationFailed` error.
+ * `CreationFailedError` error.
  *
  * @api public
  */
-const CreationFailedError = SuperError.subclass('CreationFailedError', {
-    code: 'CREATION_FAILED'
-});
+function CreationFailedError(message, cause) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'CreationFailedError';
+  this.message = message;
+  this.code = 'CREATION_FAILED';
+  this.cause = cause;
+}
+
+/**
+ * Inherit from `Error`.
+ */
+CreationFailedError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `CreationFailedError`.

--- a/lib/errors/creationfailed.js
+++ b/lib/errors/creationfailed.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `CreationFailed` error.
+ *
+ * @api public
+ */
+const CreationFailedError = SuperError.subclass('CreationFailedError', {
+    code: 'CREATION_FAILED'
+});
+
+/**
+ * Expose `CreationFailedError`.
+ */
+module.exports = CreationFailedError;

--- a/lib/errors/invalidargument.js
+++ b/lib/errors/invalidargument.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `InvalidArgument` error.
+ *
+ * @api public
+ */
+const InvalidArgumentError = SuperError.subclass('InvalidArgument', {
+    code: 'INVALID_ARGUMENT'
+});
+
+/**
+ * Expose `InvalidArgumentError`.
+ */
+module.exports = InvalidArgumentError;

--- a/lib/errors/invalidargument.js
+++ b/lib/errors/invalidargument.js
@@ -1,12 +1,21 @@
-const SuperError = require('super-error');
 /**
- * `InvalidArgument` error.
+ * `InvalidArgumentError` error.
  *
  * @api public
  */
-const InvalidArgumentError = SuperError.subclass('InvalidArgument', {
-    code: 'INVALID_ARGUMENT'
-});
+function InvalidArgumentError(message) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'InvalidArgumentError';
+  this.message = message;
+  this.code = 'INVALID_ARGUMENT';
+}
+
+/**
+ * Inherit from `Error`.
+ */
+InvalidArgumentError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `InvalidArgumentError`.

--- a/lib/errors/notimplemented.js
+++ b/lib/errors/notimplemented.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `NotImplemented` error.
+ *
+ * @api public
+ */
+const NotImplementedError = SuperError.subclass('NotImplemented', {
+    code: 'NOT_IMPLEMENTED'
+});
+
+/**
+ * Expose `NotImplementedError`.
+ */
+module.exports = NotImplementedError;

--- a/lib/errors/notimplemented.js
+++ b/lib/errors/notimplemented.js
@@ -1,12 +1,21 @@
-const SuperError = require('super-error');
 /**
- * `NotImplemented` error.
+ * `NotImplementedError` error.
  *
  * @api public
  */
-const NotImplementedError = SuperError.subclass('NotImplemented', {
-    code: 'NOT_IMPLEMENTED'
-});
+function NotImplementedError(message) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'NotImplementedError';
+  this.message = message;
+  this.code = 'NOT_IMPLEMENTED';
+}
+
+/**
+ * Inherit from `Error`.
+ */
+NotImplementedError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `NotImplementedError`.

--- a/lib/errors/resolutionfailed.js
+++ b/lib/errors/resolutionfailed.js
@@ -1,12 +1,21 @@
-const SuperError = require('super-error');
 /**
- * `ResolutionFailed` error.
+ * `ResolutionFailedError` error.
  *
  * @api public
  */
-const ResolutionFailedError = SuperError.subclass('ResolutionFailedError', {
-    code: 'RESOLUTION_FAILED'
-});
+function ResolutionFailedError(message) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'ResolutionFailedError';
+  this.message = message;
+  this.code = 'RESOLUTION_FAILED';
+}
+
+/**
+ * Inherit from `Error`.
+ */
+ResolutionFailedError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `ResolutionFailedError`.

--- a/lib/errors/resolutionfailed.js
+++ b/lib/errors/resolutionfailed.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `ResolutionFailed` error.
+ *
+ * @api public
+ */
+const ResolutionFailedError = SuperError.subclass('ResolutionFailedError', {
+    code: 'RESOLUTION_FAILED'
+});
+
+/**
+ * Expose `ResolutionFailedError`.
+ */
+module.exports = ResolutionFailedError;

--- a/lib/errors/specinitfailed.js
+++ b/lib/errors/specinitfailed.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `SpecInitFailed` error.
+ *
+ * @api public
+ */
+const SpecInitFailedError = SuperError.subclass('SpecInitFailedError', {
+    code: 'SPEC_INIT_FAILED'
+});
+
+/**
+ * Expose `SpecInitFailedError`.
+ */
+module.exports = SpecInitFailedError;

--- a/lib/errors/specinitfailed.js
+++ b/lib/errors/specinitfailed.js
@@ -1,12 +1,21 @@
-const SuperError = require('super-error');
 /**
- * `SpecInitFailed` error.
+ * `SpecInitFailedError` error.
  *
  * @api public
  */
-const SpecInitFailedError = SuperError.subclass('SpecInitFailedError', {
-    code: 'SPEC_INIT_FAILED'
-});
+function SpecInitFailedError(message) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'SpecInitFailedError';
+  this.message = message;
+  this.code = 'SPEC_INIT_FAILED';
+}
+
+/**
+ * Inherit from `Error`.
+ */
+SpecInitFailedError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `SpecInitFailedError`.

--- a/lib/errors/specinstantiationfailed.js
+++ b/lib/errors/specinstantiationfailed.js
@@ -1,0 +1,14 @@
+const SuperError = require('super-error');
+/**
+ * `SpecInstantiationFailed` error.
+ *
+ * @api public
+ */
+const SpecInstantiationFailedError = SuperError.subclass('SpecInstantiationFailedError', {
+    code: 'SPEC_INSTANTIATION_FOUND'
+});
+
+/**
+ * Expose `SpecInstantiationFailedError`.
+ */
+module.exports = SpecInstantiationFailedError;

--- a/lib/errors/specinstantiationfailed.js
+++ b/lib/errors/specinstantiationfailed.js
@@ -1,12 +1,22 @@
-const SuperError = require('super-error');
 /**
- * `SpecInstantiationFailed` error.
+ * `SpecInstantiationFailedError` error.
  *
  * @api public
  */
-const SpecInstantiationFailedError = SuperError.subclass('SpecInstantiationFailedError', {
-    code: 'SPEC_INSTANTIATION_FOUND'
-});
+function SpecInstantiationFailedError(message, cause) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'SpecInstantiationFailedError';
+  this.message = message;
+  this.code = 'SPEC_INSTANTIATION_FOUND';
+  this.cause = cause;
+}
+
+/**
+ * Inherit from `Error`.
+ */
+SpecInstantiationFailedError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `SpecInstantiationFailedError`.

--- a/lib/errors/specnotfound.js
+++ b/lib/errors/specnotfound.js
@@ -1,12 +1,21 @@
-const SuperError = require('super-error');
 /**
  * `SpecNotFound` error.
  *
  * @api public
  */
-const SpecNotFoundError = SuperError.subclass('SpecNotFoundError', {
-    code: 'SPEC_NOT_FOUND'
-});
+function SpecNotFoundError(message) {
+  Error.call(this);
+  Error.captureStackTrace(this, arguments.callee);
+  this.name = 'SpecNotFoundError';
+  this.message = message;
+  this.code = 'SPEC_NOT_FOUND';
+}
+
+/**
+ * Inherit from `Error`.
+ */
+SpecNotFoundError.prototype.__proto__ = Error.prototype;
+
 
 /**
  * Expose `SpecNotFoundError`.

--- a/lib/errors/specnotfound.js
+++ b/lib/errors/specnotfound.js
@@ -1,21 +1,12 @@
+const SuperError = require('super-error');
 /**
  * `SpecNotFound` error.
  *
  * @api public
  */
-function SpecNotFoundError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.name = 'SpecNotFoundError';
-  this.message = message;
-  this.code = 'SPEC_NOT_FOUND';
-}
-
-/**
- * Inherit from `Error`.
- */
-SpecNotFoundError.prototype.__proto__ = Error.prototype;
-
+const SpecNotFoundError = SuperError.subclass('SpecNotFoundError', {
+    code: 'SPEC_NOT_FOUND'
+});
 
 /**
  * Expose `SpecNotFoundError`.

--- a/lib/patterns/constructor.js
+++ b/lib/patterns/constructor.js
@@ -1,7 +1,8 @@
 // Load modules.
 var Spec = require('../spec')
   , util = require('util')
-  , debug = require('debug')('electrolyte');
+  , debug = require('debug')('electrolyte')
+  , InvalidArgumentError = require('../errors/invalidargument');
 
 
 /**
@@ -46,7 +47,7 @@ ConstructorSpec.prototype.instantiate = function() {
   case  9: return new ctor(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
   case 10: return new ctor(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8], args[9]);
   }
-  throw new Error("Constructor for object '" + this.id + "' requires too many arguments");
+  throw new InvalidArgumentError("Constructor for object '" + this.id + "' requires too many arguments");
 }
 
 

--- a/lib/sources/node_modules.js
+++ b/lib/sources/node_modules.js
@@ -26,7 +26,7 @@ module.exports = function() {
       module['@literal'] = true;
       return module;
     } catch (ex) {
-      throw new SpecInstantiationFailedError('Could not create instance for "' + id + '"').causedBy(ex);
+      throw new SpecInstantiationFailedError('Could not create instance for "' + id + '"', ex);
     }
   };
 };

--- a/lib/sources/node_modules.js
+++ b/lib/sources/node_modules.js
@@ -16,6 +16,8 @@
  * @return {function}
  * @public
  */
+var SpecInstantiationFailedError = require('../errors/specinstantiationfailed');
+
 module.exports = function() {
   
   return function(id) {
@@ -24,7 +26,7 @@ module.exports = function() {
       module['@literal'] = true;
       return module;
     } catch (ex) {
-      return;
+      throw new SpecInstantiationFailedError('Could not create instance for "' + id + '"').causedBy(ex);
     }
   };
 };

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -1,5 +1,6 @@
 // Load modules.
 var debug = require('debug')('electrolyte')
+  , NotImplementedError = require('./errors/notimplemented')
   , Promise = require('promise');
 
 
@@ -109,7 +110,7 @@ Spec.prototype.create = function(container) {
  * @private
  */
 Spec.prototype.instantiate = function() {
-  throw new Error("Spec#instantiate must be overridden by subclass");
+  throw new NotImplementedError("Spec#instantiate must be overridden by subclass");
 }
 
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "debug": "^2.2.0",
     "depd": "^1.0.1",
     "promise": "^7.1.1",
-    "scripts": "0.1.x",
-    "super-error": "~2.0.0"
+    "scripts": "0.1.x"
   },
   "devDependencies": {
     "chai": "3.x.x",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "debug": "^2.2.0",
     "depd": "^1.0.1",
     "promise": "^7.1.1",
-    "scripts": "0.1.x"
+    "scripts": "0.1.x",
+    "super-error": "~2.0.0"
   },
   "devDependencies": {
     "chai": "3.x.x",

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -400,7 +400,7 @@ describe('Container', function() {
       it('should throw an error', function() {
         expect(function() {
           container.use('test', undefined);
-        }).to.throw(Error, "InvalidArgument: Container#use requires a `s` to be either object with `load` method or function, \'undefined\' has been passed");
+        }).to.throw(Error, "InvalidArgumentError: Container#use requires a `s` to be either object with `load` method or function, \'undefined\' has been passed");
       });
     });
   });

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -400,7 +400,7 @@ describe('Container', function() {
       it('should throw an error', function() {
         expect(function() {
           container.use('test', undefined);
-        }).to.throw(Error, "Container#use requires a load function, was passed a 'undefined'");
+        }).to.throw(Error, "InvalidArgument: Container#use requires a `s` to be either object with `load` method or function, \'undefined\' has been passed");
       });
     });
   });

--- a/test/sources/node_modules.test.js
+++ b/test/sources/node_modules.test.js
@@ -1,4 +1,5 @@
 var node_modules = require('../../lib/sources/node_modules');
+var SpecInstantiationFailedError = require('../../lib/errors/specinstantiationfailed');
 
 describe('source/node_modules', function() {
   var source = node_modules()
@@ -9,8 +10,9 @@ describe('source/node_modules', function() {
   });
   
   it('should return undefined if module not found', function() {
-    var obj = source('fubar');
-    expect(obj).to.be.undefined;
+    expect(function() {
+      source('fubar');
+    }).to.throw(SpecInstantiationFailedError);
   })
   
 });


### PR DESCRIPTION
This is roughly equivalent to #62, but does not take a dependency on `super-error`.

It also reverts non-functional changes to spec registration, which are unrelated to error handling: https://github.com/jaredhanson/electrolyte/pull/62/files#diff-50ac0edef58dc8c3df00d1e6c7ed9b7eL82