### PR TITLE
More expressive Error stack : ComponentNotFoundError 

### DIFF
--- a/lib/errors/componentcreate.js
+++ b/lib/errors/componentcreate.js
@@ -4,7 +4,7 @@
  * @api public
  */
 function ComponentCreateError(message) {
-  // from https://stackoverflow.com/a/17936621/824979
+  // from https://stackoverflow.com/questions/8802845/inheriting-from-the-error-object-where-is-the-message-property
   const temp = Error.apply(this, arguments);
   temp.name = this.name = 'ComponentCreateError';
   temp.code = this.code = 'COMPONENT_CREATE_ERROR';

--- a/lib/errors/componentcreate.js
+++ b/lib/errors/componentcreate.js
@@ -4,17 +4,25 @@
  * @api public
  */
 function ComponentCreateError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.message = message;
-  this.code = 'COMPONENT_CREATE_ERROR';
+  // from https://stackoverflow.com/a/17936621/824979
+  const temp = Error.apply(this, arguments);
+  temp.name = this.name = 'ComponentCreateError';
+  temp.code = this.code = 'COMPONENT_CREATE_ERROR';
+  this.message = temp.message;
+  Object.defineProperty(this, 'stack', {
+      get: function() {
+          return temp.stack
+      },
+      configurable: true
+  })
 }
 
 /**
  * Inherit from `Error`.
  */
-ComponentCreateError.prototype.__proto__ = Error.prototype;
-
+const IntermediateInheritor = function () {};
+IntermediateInheritor.prototype = Error.prototype;
+ComponentCreateError.prototype = new IntermediateInheritor();
 
 /**
  * Expose `ComponentCreateError`.

--- a/lib/errors/componentnotfound.js
+++ b/lib/errors/componentnotfound.js
@@ -4,7 +4,7 @@
  * @api public
  */
 function ComponentNotFoundError(message) {
-  // from https://stackoverflow.com/a/17936621/824979
+  // from https://stackoverflow.com/questions/8802845/inheriting-from-the-error-object-where-is-the-message-property
   const temp = Error.apply(this, arguments);
   temp.name = this.name = 'ComponentNotFoundError';
   temp.code = this.code = 'COMPONENT_NOT_FOUND';

--- a/lib/errors/componentnotfound.js
+++ b/lib/errors/componentnotfound.js
@@ -7,19 +7,14 @@ function ComponentNotFoundError(message) {
   // from https://stackoverflow.com/a/17936621/824979
   const temp = Error.apply(this, arguments);
   temp.name = this.name = 'ComponentNotFoundError';
-  temp.code = this.code = 'COMPONENT_NOT_FOUND_CUSTOM';
+  temp.code = this.code = 'COMPONENT_NOT_FOUND';
   this.message = temp.message;
-  if(Object.defineProperty) {
-      // getter for more optimizy goodness
-      Object.defineProperty(this, 'stack', {
-          get: function() {
-              return temp.stack
-          },
-          configurable: true // so you can change it if you want
-      })
-  } else {
-      this.stack = temp.stack
-  }
+  Object.defineProperty(this, 'stack', {
+      get: function() {
+          return temp.stack
+      },
+      configurable: true
+  })
   this.name = "ComponentNotFoundError";
 }
 

--- a/lib/errors/componentnotfound.js
+++ b/lib/errors/componentnotfound.js
@@ -4,17 +4,32 @@
  * @api public
  */
 function ComponentNotFoundError(message) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.message = message;
-  this.code = 'COMPONENT_NOT_FOUND';
+  // from https://stackoverflow.com/a/17936621/824979
+  const temp = Error.apply(this, arguments);
+  temp.name = this.name = 'ComponentNotFoundError';
+  temp.code = this.code = 'COMPONENT_NOT_FOUND_CUSTOM';
+  this.message = temp.message;
+  if(Object.defineProperty) {
+      // getter for more optimizy goodness
+      Object.defineProperty(this, 'stack', {
+          get: function() {
+              return temp.stack
+          },
+          configurable: true // so you can change it if you want
+      })
+  } else {
+      this.stack = temp.stack
+  }
+  this.name = "ComponentNotFoundError";
 }
 
 /**
  * Inherit from `Error`.
  */
-ComponentNotFoundError.prototype.__proto__ = Error.prototype;
 
+const IntermediateInheritor = function () {};
+IntermediateInheritor.prototype = Error.prototype
+ComponentNotFoundError.prototype = new IntermediateInheritor()
 
 /**
  * Expose `ComponentNotFoundError`.

--- a/lib/errors/componentnotfound.js
+++ b/lib/errors/componentnotfound.js
@@ -15,7 +15,6 @@ function ComponentNotFoundError(message) {
       },
       configurable: true
   })
-  this.name = "ComponentNotFoundError";
 }
 
 /**

--- a/lib/errors/interfacenotfound.js
+++ b/lib/errors/interfacenotfound.js
@@ -4,17 +4,26 @@
  * @api public
  */
 function InterfaceNotFoundError(message, iface) {
-  Error.call(this);
-  Error.captureStackTrace(this, arguments.callee);
-  this.message = message;
-  this.code = 'INTERFACE_NOT_FOUND';
+  // from https://stackoverflow.com/a/17936621/824979
+  const temp = Error.apply(this, arguments);
+  temp.name = this.name = 'InterfaceNotFoundError';
+  temp.code = this.code = 'INTERFACE_NOT_FOUND';
+  this.message = temp.message;
+  Object.defineProperty(this, 'stack', {
+      get: function() {
+          return temp.stack
+      },
+      configurable: true
+  })
   this.interface = iface;
 }
 
 /**
  * Inherit from `Error`.
  */
-InterfaceNotFoundError.prototype.__proto__ = Error.prototype;
+const IntermediateInheritor = function () {};
+IntermediateInheritor.prototype = Error.prototype;
+InterfaceNotFoundError.prototype = new IntermediateInheritor();
 
 
 /**

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -73,7 +73,71 @@ describe('Container', function() {
       });
       
     });
-    
+    describe('unknown interface', function() {
+      
+      describe('created without a parent', function() {
+        var error;
+        
+        before(function(done) {
+          container.create('$unknown')
+            .then(function(obj) {
+              done(new Error('should not create object'));
+            })
+            .catch(function(err) {
+              error = err;
+              done();
+            });
+        })
+        
+        it('should fail with error', function() {
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal("Cannot find component implementing interface '$unknown' required by 'unknown'");
+          expect(error.code).to.equal("INTERFACE_NOT_FOUND");
+          expect(error.stack.split("\n")[0]).to.equal("InterfaceNotFoundError: Cannot find component implementing interface '$unknown' required by 'unknown'")
+        });
+      });
+      
+      describe('created with a parent', function() {
+        var error;
+        
+        before(function(done) {
+          container.create('$unknown', { id: 'main' })
+            .then(function(obj) {
+              done(new Error('should not create object'));
+            })
+            .catch(function(err) {
+              error = err;
+              done();
+            });
+        })
+        
+        it('should fail with error', function() {
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal("Cannot find component implementing interface '$unknown' required by 'main'");
+        });
+      });
+      
+      describe('created with a parent, lacking an id', function() {
+        var error;
+        
+        before(function(done) {
+          container.create('$unknown', {})
+            .then(function(obj) {
+              done(new Error('should not create object'));
+            })
+            .catch(function(err) {
+              error = err;
+              done();
+            });
+        })
+        
+        it('should fail with error', function() {
+          expect(error).to.be.an.instanceOf(Error);
+          expect(error.message).to.equal("Cannot find component implementing interface '$unknown' required by 'unknown'");
+        });
+      });
+      
+    });
     describe.skip('async component', function() {
       var container = new Container();
       container.use(require('./fixtures/sources/async'));

--- a/test/container.test.js
+++ b/test/container.test.js
@@ -27,6 +27,8 @@ describe('Container', function() {
         it('should fail with error', function() {
           expect(error).to.be.an.instanceOf(Error);
           expect(error.message).to.equal("Unable to create component 'unknown' required by 'unknown'");
+          expect(error.code).to.equal("COMPONENT_NOT_FOUND");
+          expect(error.stack.split("\n")[0]).to.equal("ComponentNotFoundError: Unable to create component 'unknown' required by 'unknown'")
         });
       });
       


### PR DESCRIPTION
Hello,

Thank you for this lib.

## before

```shell
        » An unexpected error was caught: Error 
      at /.../electrolyte/lib/container.js:187:18 
```

## after
```shell
        » An unexpected error was caught: ComponentNotFoundError: Unable to create component 'parent' required by 'child' 
      at ComponentNotFoundError (/.../electrolyte/lib/errors/componentnotfound.js:7:20) 
```

I've followed https://stackoverflow.com/questions/783818/how-do-i-create-a-custom-error-in-javascript